### PR TITLE
Prevent people from sending banned names

### DIFF
--- a/src/Starlight.Server/Content/Languages/en-us.json
+++ b/src/Starlight.Server/Content/Languages/en-us.json
@@ -1,15 +1,17 @@
 {
-    "Register": {
-        "AccountExists": "Account already exists.",
-        "AccountCreated": "Account has been created."
-    },
+  "Register": {
+    "AccountBanned": "This name is reserved or banned.",
+    "AccountExists": "Account already exists.",
+    "AccountCreated": "Account has been created."
+  },
     "Login": {
         "InvalidUsernamePassword": "Invalid username or password."
     },
     "CreateCharacter": {
         "AccountNotFound": "Account not found.",
         "SlotNotEmpty": "This character slot is not empty!",
-        "CharacterNameTaken": "This character name has already been taken."
+        "CharacterNameTaken": "This character name has already been taken.",
+        "AccountBanned": "This name is reserved or banned."
     },
     "DeleteCharacter": {
         "AccountNotFound": "Account not found.",

--- a/src/Starlight.Server/Handlers/LoginPacketHandler.cs
+++ b/src/Starlight.Server/Handlers/LoginPacketHandler.cs
@@ -16,6 +16,12 @@ namespace Starlight.Server.Handlers
     public class LoginPacketHandler : AbstractPacketHandler<LoginPacket>
     {
         public override void HandlePacket(RequestContext requestContext, LoginPacket packet) {
+
+            if (!DenyList.Instance.Sanitize(packet.Username.Trim()).Equals(packet.Username.Trim())) {
+                Log.Warning("[" + requestContext.ConnectionId + "] Hack attempt! Sanitized username!");
+            }
+
+            packet.Username = DenyList.Instance.Sanitize(packet.Username.Trim());
             var user = requestContext.DbContext.Users.Include(x => x.Characters)
                                                      .Where(x => x.Username.ToLower() == packet.Username.ToLower()).FirstOrDefault();
             Log.Information("[" + requestContext.ConnectionId + "] Login as user " + packet.Username);

--- a/src/Starlight.Server/Program.cs
+++ b/src/Starlight.Server/Program.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using Starlight.Server.GameLogic;
 using Starlight.Server.Data;
 using System.Linq;
+using Starlight.Server.Security;
 
 namespace Starlight.Server
 {
@@ -20,7 +21,7 @@ namespace Starlight.Server
     {
         static void Main(string[] args) {
             var server = new StarlightServer(new Telepathy.Server());
-            
+
             try {
                 var configuration = LoadConfiguration();
                 if (configuration.LogFile == null) {
@@ -40,8 +41,14 @@ namespace Starlight.Server
                 Log.Information("Starlight Server " + Assembly.GetEntryAssembly().GetName().Version.ToString());
 
                 TranslationManager.Instance.ImportFromDocument(Path.Combine(Directory.GetCurrentDirectory(), "Content", "Languages", "en-us.json"));
+                DenyList.Instance.ImportFromDocument(Path.Combine(Directory.GetCurrentDirectory(), "denylist.txt"));
                 Setup.RunSetup(configuration);
 
+                //Validate denylist
+                if (!DenyList.Instance.CheckDenied("root") || !DenyList.Instance.CheckDenied("admin") || !DenyList.Instance.CheckDenied("demo") || !DenyList.Instance.CheckDenied("sql") || !DenyList.Instance.CheckDenied("test") || !DenyList.Instance.CheckDenied("system")) {
+                    Log.Warning("Denylist is incomplete or missing!");
+                }
+                
                 // start the server
                 server.Server.Start(configuration.Port);
 

--- a/src/Starlight.Server/Security/DenyList.cs
+++ b/src/Starlight.Server/Security/DenyList.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Starlight.Server.Security
+{
+    class DenyList
+    {
+        static DenyList instance;
+        public static DenyList Instance {
+            get {
+                if (instance == null) {
+                    instance = new DenyList();
+                }
+
+                return instance;
+            }
+        }
+
+        private readonly List<string> strings;
+
+        public DenyList() {
+            this.strings = new List<string>();
+        }
+
+        public void AddString(string value) {
+            this.strings.Add(value);
+        }
+
+        public string Sanitize(string value) {
+            return Regex.Escape(value);
+        }
+
+        public Boolean CheckDenied(string value) {
+            if (strings.Contains(value)) {
+                return true;
+            }
+            foreach (var check in strings) {
+                if (Regex.IsMatch(value, check)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void ImportFromDocument(string documentPath) {
+            using (var fileStream = new FileStream(documentPath, FileMode.Open)) {
+                using (var streamReader = new StreamReader(fileStream)) {
+                    string line = null;
+                    do{
+                        line = streamReader.ReadLine();
+                        if (line != null) {
+                            AddString(line);
+                        }
+                    }while (line != null) ;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
To prevent people from registering themselves with banned words, and also to create a list of "banned" usernames. People with these words can still log in, but they cannot be created without intervention from the administrator.